### PR TITLE
Default error handling

### DIFF
--- a/GiEnJul/Controllers/ErrorController.cs
+++ b/GiEnJul/Controllers/ErrorController.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Diagnostics;
+
+namespace GiEnJul.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class ErrorController : ControllerBase
+    {
+        [Route("/error-local-development")]
+        public IActionResult ErrorLocalDevelopment([FromServices] IWebHostEnvironment webHostEnvironment)
+        {
+
+            if (webHostEnvironment.EnvironmentName != "Development")
+            {
+                throw new InvalidOperationException(
+                    "This shouldn't be invoked in non-development environments.");
+            }
+
+            var context = HttpContext.Features.Get<IExceptionHandlerFeature>();
+
+            return Problem(
+                detail: context.Error.StackTrace,
+                title: context.Error.Message);
+        }
+
+        [Route("/error")]
+        public IActionResult Error() => Problem();
+    }
+}

--- a/GiEnJul/Startup.cs
+++ b/GiEnJul/Startup.cs
@@ -6,7 +6,6 @@ using Microsoft.AspNetCore.SpaServices.ReactDevelopmentServer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-
 namespace GiEnJul
 {
     public class Startup
@@ -42,6 +41,7 @@ namespace GiEnJul
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
+                app.UseExceptionHandler("/error-local-development");
             }
             else
             {
@@ -53,7 +53,6 @@ namespace GiEnJul
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseSpaStaticFiles();
-
             app.UseRouting();
 
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
Closes #10
Added an error controller that sends an RFC 7807-compliant payload to the client.