### PR TITLE
Changed return types for GiverController and GiverRepository

### DIFF
--- a/GiEnJul.Test/ControllerTests/GiverControllerTest.cs
+++ b/GiEnJul.Test/ControllerTests/GiverControllerTest.cs
@@ -90,17 +90,17 @@ namespace GiEnJul.Test.ControllerTests
             var fakeEvent = new Entities.Event { RowKey = "Stavanger", PartitionKey = "Jul21", DeliveryAdress = "Somewhere", EndDate = DateTime.UtcNow, StartDate = DateTime.UtcNow };
             mockEventRepo.Setup(x => x.GetActiveEventForLocationAsync(It.IsAny<string>())).ReturnsAsync(fakeEvent.PartitionKey);
 
-            var entity = new Entities.Giver(fakeEvent.RowKey, fakeEvent.PartitionKey) { MaxRecievers = 5, PhoneNumber = "12312312", FullName = "FullName", Email = "Email" };
-            mockGiverRepo.Setup(x => x.InsertOrReplaceAsync(It.IsAny<Models.Giver>())).ReturnsAsync(entity);
+            var fakeModel = new Models.Giver {RowKey = Guid.NewGuid().ToString(), PartitionKey = $"{fakeEvent.RowKey}_{fakeEvent.PartitionKey}", MaxRecievers = 5, PhoneNumber = "12312312", FullName = "FullName", Email = "Email" };
+            mockGiverRepo.Setup(x => x.InsertOrReplaceAsync(It.IsAny<Models.Giver>())).ReturnsAsync(fakeModel);
 
             //Act
             var result = await _controller.PostAsync(new PostGiverDto() { Location = "Not Empty", MaxRecievers = 5, PhoneNumber = "12312312", FullName = "FullName", Email = "Email" });
 
             //Assert
-            var actionResult = Assert.IsType<ActionResult<Entities.Giver>>(result);
+            var actionResult = Assert.IsType<ActionResult<PostGiverResultDto>>(result);
             var createdAtActionResult = Assert.IsType<CreatedAtActionResult>(actionResult.Result);
-            var returnValue = Assert.IsType<Entities.Giver>(createdAtActionResult.Value);
-            Assert.Equal((entity.RowKey, entity.PartitionKey), (returnValue.RowKey, returnValue.PartitionKey));
+            var returnValue = Assert.IsType<PostGiverResultDto>(createdAtActionResult.Value);
+            Assert.Equal((fakeModel.FullName, fakeModel.Email), (returnValue.FullName, returnValue.Email));
 
             mockEventRepo.Verify(x => x.GetActiveEventForLocationAsync(It.IsAny<string>()), Times.Once());
             mockGiverRepo.Verify(x => x.InsertOrReplaceAsync(It.IsAny<Models.Giver>()), Times.Once());

--- a/GiEnJul/Controllers/GiverController.cs
+++ b/GiEnJul/Controllers/GiverController.cs
@@ -27,13 +27,14 @@ namespace GiEnJul.Controllers
 
         // POST api/<GiverController>
         [HttpPost]
-        public async Task<ActionResult<Entities.Giver>> PostAsync([FromBody] PostGiverDto giverDto)
+        public async Task<ActionResult<PostGiverResultDto>> PostAsync([FromBody] PostGiverDto giverDto)
         {
             var giver = _mapper.Map<Giver>(giverDto);
             giver.EventName = await _eventRepository.GetActiveEventForLocationAsync(giverDto.Location);
 
-            var result = await _giverRepository.InsertOrReplaceAsync(giver);
-            return CreatedAtAction(nameof(result), result);
+            var insertedAsDto = _mapper.Map<PostGiverResultDto>(await _giverRepository.InsertOrReplaceAsync(giver));
+
+            return CreatedAtAction(nameof(insertedAsDto), insertedAsDto);
         }
     }
 }

--- a/GiEnJul/Dtos/PostGiverResultDto.cs
+++ b/GiEnJul/Dtos/PostGiverResultDto.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace GiEnJul.Dtos
+{
+    public class PostGiverResultDto 
+    {
+        public string FullName { get; set; }
+        public string Email { get; set; }
+    }
+}

--- a/GiEnJul/Dtos/PostGiverResultDto.cs
+++ b/GiEnJul/Dtos/PostGiverResultDto.cs
@@ -1,11 +1,4 @@
-﻿using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace GiEnJul.Dtos
+﻿namespace GiEnJul.Dtos
 {
     public class PostGiverResultDto 
     {

--- a/GiEnJul/Features/GiverReposiory.cs
+++ b/GiEnJul/Features/GiverReposiory.cs
@@ -1,30 +1,31 @@
 using AutoMapper;
-using GiEnJul.Entities;
 using GiEnJul.Infrastructure;
 using Serilog;
 using System.Threading.Tasks;
 
 namespace GiEnJul.Features
 {
-    public interface IGiverRepository : IGenericRepository<Giver>
+    public interface IGiverRepository : IGenericRepository<Entities.Giver>
     {
-        Task<Giver> DeleteAsync(Models.Giver model);
-        Task<Giver> InsertOrReplaceAsync(Models.Giver model);
+        Task<Models.Giver> DeleteAsync(Models.Giver model);
+        Task<Models.Giver> InsertOrReplaceAsync(Models.Giver model);
     }
 
-    public class GiverRepository : GenericRepository<Giver>, IGiverRepository
+    public class GiverRepository : GenericRepository<Entities.Giver>, IGiverRepository
     {
         public GiverRepository(ISettings settings, IMapper mapper, ILogger logger, string tableName = "Giver") : base(settings, tableName, mapper, logger)
         { }
 
-        public async Task<Giver> DeleteAsync(Models.Giver model)
+        public async Task<Models.Giver> DeleteAsync(Models.Giver model)
         {
-            return await DeleteAsync(_mapper.Map<Giver>(model));
+            var deleted = await DeleteAsync(_mapper.Map<Entities.Giver>(model));
+            return _mapper.Map<Models.Giver>(deleted);
         }
 
-        public async Task<Giver> InsertOrReplaceAsync(Models.Giver model)
+        public async Task<Models.Giver> InsertOrReplaceAsync(Models.Giver model)
         {
-            return await InsertOrReplaceAsync(_mapper.Map<Giver>(model));
+            var inserted = await InsertOrReplaceAsync(_mapper.Map<Entities.Giver>(model));
+            return _mapper.Map<Models.Giver>(inserted);
         }
     }
 }

--- a/GiEnJul/Infrastructure/AutoMapperProfile.cs
+++ b/GiEnJul/Infrastructure/AutoMapperProfile.cs
@@ -45,6 +45,11 @@ namespace GiEnJul.Infrastructure
                 .ForMember(x => x.RowKey, opt => opt.Ignore())
                 .ForMember(x => x.Timestamp, opt => opt.Ignore())
                 .ForMember(x => x.ETag, opt => opt.Ignore());
+
+            CreateMap<Entities.Giver, Models.Giver>();
+
+            CreateMap<Models.Giver, Dtos.PostGiverResultDto>();
+
         }
     }
 }


### PR DESCRIPTION
Added PostGiverResultDto, containing only Fullname and Email. The result from adding a new Giver is therefore changed to only contain necessary properties:
![image](https://user-images.githubusercontent.com/45152025/124566351-4105b400-de43-11eb-9874-8c16ec2335b2.png)

Changed return types to restrict Controllers to only use Dto and Models, and Repositories to only use Models and Entities.
