### PR TITLE
Changed the access modifiers of GenericRepository, and removed the GenericRepo interface

### DIFF
--- a/GiEnJul/Controllers/AdminController.cs
+++ b/GiEnJul/Controllers/AdminController.cs
@@ -37,8 +37,8 @@ namespace GiEnJul.Controllers
         // }
         
         [HttpGet("givers")]
-        public async Task<List<Models.Giver>> GetGiversAsync() {
-            return _mapper.Map<List<Models.Giver>>(await _giverRepository.GetAllAsync());
+        public async Task<List<Giver>> GetGiversAsync() {
+            return _mapper.Map<List<Giver>>(await _giverRepository.GetAllAsModelAsync());
             // return _mapper.Map<List<Models.Giver>>(await _giverRepository.GetAllAsync()).OrderBy(x => x.FullName).ToList();
         }
     }

--- a/GiEnJul/Controllers/AdminController.cs
+++ b/GiEnJul/Controllers/AdminController.cs
@@ -37,8 +37,8 @@ namespace GiEnJul.Controllers
         // }
         
         [HttpGet("givers")]
-        public async Task<List<Giver>> GetGiversAsync() {
-            return _mapper.Map<List<Giver>>(await _giverRepository.GetAllAsModelAsync());
+        public async Task<IEnumerable<Giver>> GetGiversAsync() {
+            return await _giverRepository.GetAllAsModelAsync();
             // return _mapper.Map<List<Models.Giver>>(await _giverRepository.GetAllAsync()).OrderBy(x => x.FullName).ToList();
         }
     }

--- a/GiEnJul/Features/ConnectionRepository.cs
+++ b/GiEnJul/Features/ConnectionRepository.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace GiEnJul.Features
 {
-    public interface IConnectionRepository : IGenericRepository<Connection>
+    public interface IConnectionRepository
     {
         Task<Connection> InsertOrReplaceAsync(Models.Giver giver);
         Task<Connection> InsertOrReplaceAsync(Models.Recipient recipient);

--- a/GiEnJul/Features/EventRepository.cs
+++ b/GiEnJul/Features/EventRepository.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace GiEnJul.Features
 {
-    public interface IEventRepository : IGenericRepository<Event>
+    public interface IEventRepository
     {
         Task<string> GetActiveEventForLocationAsync(string location);
         Task<string[]> GetLocationsWithActiveEventAsync();

--- a/GiEnJul/Features/GenericRepository.cs
+++ b/GiEnJul/Features/GenericRepository.cs
@@ -9,28 +9,11 @@ using System.Threading.Tasks;
 
 namespace GiEnJul.Features
 {
-    public interface IGenericRepository<T> where T : EntityBase, new()
+    public class GenericRepository<T> where T : EntityBase, new()
     {
-        public CloudTable _table { get; }
-        public IMapper _mapper { get; set; }
-        public ILogger _log { get; set; }
-
-        Task<T> GetAsync(string partitionKey, string rowKey);
-        Task<T> InsertOrReplaceAsync(T entity);
-        Task<TableBatchResult> InsertOrReplaceBatchAsync(IEnumerable<T> entities);
-        Task<T> DeleteAsync(T entity);
-        Task<T> DeleteAsync(string partitionKey, string rowKey);
-        Task<TableBatchResult> DeleteBatchAsync(IEnumerable<T> entities);
-
-        Task<IEnumerable<T>> GetAllAsync();
-        Task<IEnumerable<T>> GetAllByQueryAsync(TableQuery<T> query);
-    }
-
-    public class GenericRepository<T> : IGenericRepository<T> where T : EntityBase, new()
-    {
-        public CloudTable _table { get; private set; }
-        public IMapper _mapper { get; set; }
-        public ILogger _log { get; set; }
+        private CloudTable _table { get; set; }
+        protected IMapper _mapper { get; set; }
+        protected ILogger _log { get; set; }
 
         public GenericRepository(ISettings settings, string tableName, IMapper mapper, ILogger log)
         {
@@ -45,7 +28,6 @@ namespace GiEnJul.Features
             try
             {
                 _table.CreateIfNotExists();
-
             }
             catch (StorageException e)
             {
@@ -54,7 +36,7 @@ namespace GiEnJul.Features
             }
         }
 
-        public async Task<T> DeleteAsync(T entity)
+        protected async Task<T> DeleteAsync(T entity)
         {
             try
             {
@@ -73,14 +55,14 @@ namespace GiEnJul.Features
             }
         }
 
-        public async Task<T> DeleteAsync(string partitionKey, string rowKey)
+        protected async Task<T> DeleteAsync(string partitionKey, string rowKey)
         {
             var entity = await GetAsync(partitionKey, rowKey);
 
             return await DeleteAsync(entity);
         }
 
-        public async Task<TableBatchResult> DeleteBatchAsync(IEnumerable<T> entities)
+        protected async Task<TableBatchResult> DeleteBatchAsync(IEnumerable<T> entities)
         {
             var batchOperation = new TableBatchOperation();
             try
@@ -101,7 +83,7 @@ namespace GiEnJul.Features
             }
         }
 
-        public async Task<T> GetAsync(string partitionKey, string rowKey)
+        protected async Task<T> GetAsync(string partitionKey, string rowKey)
         {
             try
             {
@@ -119,7 +101,7 @@ namespace GiEnJul.Features
             }
         }
 
-        public async Task<T> InsertOrReplaceAsync(T entity)
+        protected async Task<T> InsertOrReplaceAsync(T entity)
         {
             try
             {
@@ -137,7 +119,7 @@ namespace GiEnJul.Features
             }
         }
 
-        public async Task<TableBatchResult> InsertOrReplaceBatchAsync(IEnumerable<T> entities)
+        protected async Task<TableBatchResult> InsertOrReplaceBatchAsync(IEnumerable<T> entities)
         {
             var batchOperation = new TableBatchOperation();
             try
@@ -158,12 +140,12 @@ namespace GiEnJul.Features
             }
         }
 
-        public async Task<IEnumerable<T>> GetAllAsync()
+        protected async Task<IEnumerable<T>> GetAllAsync()
         {
             return await GetAllByQueryAsync(new TableQuery<T>());
         }
 
-        public async Task<IEnumerable<T>> GetAllByQueryAsync(TableQuery<T> query)
+        protected async Task<IEnumerable<T>> GetAllByQueryAsync(TableQuery<T> query)
         {
             try
             {

--- a/GiEnJul/Features/GenericRepository.cs
+++ b/GiEnJul/Features/GenericRepository.cs
@@ -15,7 +15,7 @@ namespace GiEnJul.Features
         protected IMapper _mapper { get; set; }
         protected ILogger _log { get; set; }
 
-        public GenericRepository(ISettings settings, string tableName, IMapper mapper, ILogger log)
+        protected GenericRepository(ISettings settings, string tableName, IMapper mapper, ILogger log)
         {
             _mapper = mapper;
             _log = log;

--- a/GiEnJul/Features/GiverRepository.cs
+++ b/GiEnJul/Features/GiverRepository.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace GiEnJul.Features
 {
-    public interface IGiverRepository : IGenericRepository<Entities.Giver>
+    public interface IGiverRepository
     {
         Task<Models.Giver> DeleteAsync(Models.Giver model);
         Task<Models.Giver> InsertOrReplaceAsync(Models.Giver model);

--- a/GiEnJul/Features/GiverRepository.cs
+++ b/GiEnJul/Features/GiverRepository.cs
@@ -1,6 +1,7 @@
 using AutoMapper;
 using GiEnJul.Infrastructure;
 using Serilog;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace GiEnJul.Features
@@ -9,6 +10,7 @@ namespace GiEnJul.Features
     {
         Task<Models.Giver> DeleteAsync(Models.Giver model);
         Task<Models.Giver> InsertOrReplaceAsync(Models.Giver model);
+        Task<IEnumerable<Models.Giver>> GetAllAsModelAsync();
     }
 
     public class GiverRepository : GenericRepository<Entities.Giver>, IGiverRepository
@@ -26,6 +28,12 @@ namespace GiEnJul.Features
         {
             var inserted = await InsertOrReplaceAsync(_mapper.Map<Entities.Giver>(model));
             return _mapper.Map<Models.Giver>(inserted);
+        }
+
+        public async Task<IEnumerable<Models.Giver>> GetAllAsModelAsync()
+        {
+            var allGivers = await GetAllAsync();
+            return _mapper.Map<IEnumerable<Models.Giver>>(allGivers);
         }
     }
 }

--- a/GiEnJul/Features/PersonRepository.cs
+++ b/GiEnJul/Features/PersonRepository.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace GiEnJul.Features
 {
-    public interface IPersonRepository : IGenericRepository<Person>
+    public interface IPersonRepository
     {
         Task<Person> DeleteAsync(Models.Person model);
         Task<TableBatchResult> DeleteBatchAsync(IEnumerable<Models.Person> models);

--- a/GiEnJul/Features/RecipientRepository.cs
+++ b/GiEnJul/Features/RecipientRepository.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace GiEnJul.Features
 {
-    public interface IRecipientRepository : IGenericRepository<Entities.Recipient>
+    public interface IRecipientRepository
     {
         Task<Models.Recipient> DeleteAsync(Models.Recipient model);
         Task<Models.Recipient> InsertOrReplaceAsync(Models.Recipient model);


### PR DESCRIPTION
Added protected to all GenericRepository-functions. Removed IGenericRepository as its implementation is not needed, and was preventing changes to access modifiers.

This should provide better maintainability to our usage of repositories.

Lets say you are using the GiverRepository in a controller, you now only have access to IGiverRepository's functions.

![image](https://user-images.githubusercontent.com/45152025/125054288-57f81080-e0a6-11eb-85e8-b54077a16c5e.png)
