### PR TITLE
Fixed fetched events to be filtered by StartDate and EndDate.

### DIFF
--- a/GiEnJul.Test/ControllerTests/GiverControllerTest.cs
+++ b/GiEnJul.Test/ControllerTests/GiverControllerTest.cs
@@ -77,7 +77,7 @@ namespace GiEnJul.Test.ControllerTests
         public async Task PostAsync_GiverRepositoryThrowsException_ControllerReturnsBadRequest()
         {
             //Arrange
-            var fakeEvent = new Entities.Event { RowKey = "Stavanger", PartitionKey = "Jul21", DeliveryAdress = "Somewhere", EndDate = DateTime.UtcNow, StartDate = DateTime.UtcNow };
+            var fakeEvent = new Entities.Event { RowKey = "Stavanger", PartitionKey = "Jul21", DeliveryAddress = "Somewhere", EndDate = DateTime.UtcNow, StartDate = DateTime.UtcNow };
             mockEventRepo.Setup(x => x.GetActiveEventForLocationAsync(It.IsAny<string>())).ReturnsAsync(fakeEvent.PartitionKey);
             mockGiverRepo.Setup(x => x.InsertOrReplaceAsync(It.IsAny<Models.Giver>())).Throws(new Exception());
 
@@ -92,7 +92,7 @@ namespace GiEnJul.Test.ControllerTests
         public async Task PostAsync_GiverRepositorySuccessfullyAddsEntity_ControllerReturnsEntityAsync()
         {
             //Arrange
-            var fakeEvent = new Entities.Event { RowKey = "Stavanger", PartitionKey = "Jul21", DeliveryAdress = "Somewhere", EndDate = DateTime.UtcNow, StartDate = DateTime.UtcNow };
+            var fakeEvent = new Entities.Event { RowKey = "Stavanger", PartitionKey = "Jul21", DeliveryAddress = "Somewhere", EndDate = DateTime.UtcNow, StartDate = DateTime.UtcNow };
             mockEventRepo.Setup(x => x.GetActiveEventForLocationAsync(It.IsAny<string>())).ReturnsAsync(fakeEvent.PartitionKey);
 
             var fakeModel = new Models.Giver { RowKey = Guid.NewGuid().ToString(), PartitionKey = $"{fakeEvent.RowKey}_{fakeEvent.PartitionKey}", MaxReceivers = 5, PhoneNumber = "12312312", FullName = "FullName", Email = "Email" };

--- a/GiEnJul/Entities/Event.cs
+++ b/GiEnJul/Entities/Event.cs
@@ -10,6 +10,6 @@ namespace GiEnJul.Entities
         public DateTime? StartDate { get; set; }
         public DateTime? EndDate { get; set; }
 
-        public string DeliveryAdress { get; set; }
+        public string DeliveryAddress { get; set; }
     }
 }

--- a/GiEnJul/Features/EventRepository.cs
+++ b/GiEnJul/Features/EventRepository.cs
@@ -14,6 +14,7 @@ namespace GiEnJul.Features
     {
         Task<string> GetActiveEventForLocationAsync(string location);
         Task<string[]> GetLocationsWithActiveEventAsync();
+        Task<string> GetDeliveryAddressForLocationAsync(string location);
     }
 
     public class EventRepository : GenericRepository<Event>, IEventRepository
@@ -24,15 +25,32 @@ namespace GiEnJul.Features
 
         public async Task<string> GetActiveEventForLocationAsync(string location)
         {
+            var eventByLocation = await GetEventByLocationAsync(location);
+            return eventByLocation.PartitionKey;
+        }
+
+        public async Task<string> GetDeliveryAddressForLocationAsync(string location)
+        {
+            var evnt = await GetEventByLocationAsync(location);
+            return evnt.DeliveryAddress;
+        }
+
+        private async Task<Event> GetEventByLocationAsync(string location)
+        {
             if (string.IsNullOrEmpty(location))
             {
                 throw new ArgumentException($"'{nameof(location)}' cannot be null or empty.", nameof(location));
             }
 
-            var query = new TableQuery<Event>()
-            {
-                FilterString = TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.Equal, location)
-            }.Take(1);
+            // RowKey == location
+            var rowKeyFilter = TableQuery.GenerateFilterCondition("RowKey", QueryComparisons.Equal, location);
+
+            var query = new TableQuery<Event>().Where(
+                TableQuery.CombineFilters(
+                    rowKeyFilter,
+                    TableOperators.And,
+                    HasActiveDates()))
+                .Take(1);
 
             var activeEvent = await GetAllByQueryAsync(query);
 
@@ -42,23 +60,28 @@ namespace GiEnJul.Features
             }
             _log.Debug("Found active event: {@0} for location: {1}", activeEvent.First().PartitionKey, location);
 
-            return activeEvent.First().PartitionKey;
+            return activeEvent.First();
         }
 
         public async Task<string[]> GetLocationsWithActiveEventAsync()
         {
-            var query = new TableQuery<Event>()
-            {
-                FilterString = TableQuery.CombineFilters(
-                    TableQuery.GenerateFilterConditionForDate("StartDate", QueryComparisons.LessThan, DateTimeOffset.UtcNow),
-                    TableOperators.And,
-                    TableQuery.GenerateFilterConditionForDate("EndDate", QueryComparisons.GreaterThan, DateTimeOffset.UtcNow))
-            };
+            var query = new TableQuery<Event>().Where(HasActiveDates());
+
             var events = await GetAllByQueryAsync(query);
 
             var locationArray = events.Select(x => x.RowKey).ToArray();
             Array.Sort(locationArray);
             return locationArray;
+        }
+
+        private string HasActiveDates()
+        {
+            // StartDate <= DateTime.Now
+            var startDatePassed = TableQuery.GenerateFilterConditionForDate("StartDate", QueryComparisons.LessThanOrEqual, DateTime.Now);
+            // EndDate >= DateTime.Now
+            var endDateNotPassed = TableQuery.GenerateFilterConditionForDate("EndDate", QueryComparisons.GreaterThanOrEqual, DateTime.Now);
+
+            return TableQuery.CombineFilters(startDatePassed, TableOperators.And, endDateNotPassed);
         }
     }
 }


### PR DESCRIPTION
Added a function to fetch DeliveryAddress of a Event, based on Location.

Also added a function HasActiveDates, which returns a filter-string for Table Storage.
The filter string will get all events with a passed startDate and an upcoming endDate.
Eg.  
StartDate <= DateTime.now <= EndDate