### PR TITLE
use batch operations for logging to increase performance

### DIFF
--- a/GiEnJul/Infrastructure/AutofacConfiguration.cs
+++ b/GiEnJul/Infrastructure/AutofacConfiguration.cs
@@ -29,7 +29,9 @@ namespace GiEnJul.Infrastructure
             var logger = new LoggerConfiguration()
                                 .MinimumLevel.Is(settings.LogLevel)
                                 .WriteTo.Console()
-                                .WriteTo.AzureTableStorage(CloudStorageAccount.Parse(settings.TableConnectionString), storageTableName: settings.LogTableName)
+                                .WriteTo.AzureTableStorage(CloudStorageAccount.Parse(settings.TableConnectionString), 
+                                                        storageTableName: settings.LogTableName, 
+                                                        writeInBatches: true)
                                 .CreateLogger();
 
             builder.Register(c => logger).As<ILogger>().SingleInstance();

--- a/GiEnJul/Properties/launchSettings.json
+++ b/GiEnJul/Properties/launchSettings.json
@@ -1,27 +1,11 @@
-﻿{
-  "iisSettings": {
-    "windowsAuthentication": false,
-    "anonymousAuthentication": true,
-    "iisExpress": {
-      "applicationUrl": "http://localhost:18936",
-      "sslPort": 44327
-    }
-  },
+{
   "profiles": {
-    "IIS Express": {
-      "commandName": "IISExpress",
-      "launchBrowser": true,
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
-      }
-    },
     "gi_en_jul": {
       "commandName": "Project",
-      "launchBrowser": true,
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
-      }
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }


### PR DESCRIPTION
use batch operations for logging to increase performance and remove annoying launch options.
each logging statement seemed to slow down the application with a slight delay as it was writing to the table, but enabling batch operations on the sink seems to fix the problem. There is no longer a guarantee for the order of the inserted log-events in the table, but they will have the correct TimeStamp so this can be used to get an accurate timeline of events.