### PR TITLE
Commented in code in the recaptcha utility, so it is disabled on dev

### DIFF
--- a/GiEnJul/Utilities/RecaptchaVerifier.cs
+++ b/GiEnJul/Utilities/RecaptchaVerifier.cs
@@ -23,12 +23,12 @@ namespace GiEnJul.Utilities
 
         public async Task<GetRecaptchaDto> VerifyAsync(string token)
         {
-            /*if (_secret == "") {  // Skips verification on dev
+            if (_secret == "") {  // Skips verification on dev
                 return new GetRecaptchaDto
                 {
                     Success = true
                 };
-            } */  // This code should be added after the recaptcha has been tested on prod
+            }
             var request = WebRequest.Create($"https://www.google.com/recaptcha/api/siteverify?secret={_secret}&response={token}");
             request.Method = "GET";
 


### PR DESCRIPTION
Fix #319 
Disables recaptch on dev. This is done because the secret isn't fetched from azure in dev.