### PR TITLE
Removed unnecessary refreshes on suggested connections page

### DIFF
--- a/ClientApp/src/components/admin/suggestedConnections/ConnectionSuggesterMacro.tsx
+++ b/ClientApp/src/components/admin/suggestedConnections/ConnectionSuggesterMacro.tsx
@@ -64,11 +64,11 @@ const ConnectionSuggesterMacro: React.FC<ConnectionSuggesterMacro> = ({
       })
       .then((response) => {
         if (response.status == 200) {
-          setState({
-            ...initialState,
+          setState((prev) => ({
+            ...prev,
             recipients: response.data,
-            refreshing: false,
-          });
+            refreshing: false
+          }))
         } else {
           alert("Kunne ikke hente familier, prøv igjen");
         }
@@ -92,7 +92,7 @@ const ConnectionSuggesterMacro: React.FC<ConnectionSuggesterMacro> = ({
           alert("Kunne ikke hente givere, prøv igjen");
         }
       });
-  }, [state.recipients]);
+  }, []);
 
   const updateSelectedRecipient = (newSelected: RecipientType): void => {
     setState((prev) => ({ ...prev, selectedRecipient: newSelected }));


### PR DESCRIPTION
Suggested connection tab will no longer refresh Givers when pressing the refresh button 