### PR TITLE
Allow multiple origins

### DIFF
--- a/GiEnJul/Startup.cs
+++ b/GiEnJul/Startup.cs
@@ -9,6 +9,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog;
+using System;
+using System.Linq;
 
 namespace GiEnJul
 {
@@ -85,7 +87,7 @@ namespace GiEnJul
                    .SetIsOriginAllowed(x =>
                    {
                        log.Verbose(x);
-                       return x == settings.ReactAppUri;
+                       return IsOriginAllowed(x, settings);
                    }));
 
             app.UseEndpoints(endpoints =>
@@ -94,6 +96,12 @@ namespace GiEnJul
                     name: "default",
                     pattern: "{controller}/{action=Index}/{id?}");
             });
+        }
+
+        private bool IsOriginAllowed(string x, ISettings settings)
+        {
+            var allowedOrigins = settings.ReactAppUri.Split(';');
+            return allowedOrigins.Contains(x);
         }
     }
 }

--- a/GiEnJul/appsettings.json
+++ b/GiEnJul/appsettings.json
@@ -18,7 +18,7 @@
   },
   "MailSettings": {
     "Mail": "noreply@gienjul.no",
-    "DisplayName": "Gi En Jul",
+    "DisplayName": "Gi en jul",
     "Password": "",
     "Host": "127.0.0.1",
     "Port": 25


### PR DESCRIPTION
This allows us to run local frontend against the dev-backend running in Azure and makes it easier to test the CDN endpoints.

We can now add multiple origins by separating them with ; in the variable list