### PR TITLE
Person comment fix

### DIFF
--- a/ClientApp/src/components/institution/FormPerson.tsx
+++ b/ClientApp/src/components/institution/FormPerson.tsx
@@ -22,6 +22,7 @@ import MessageDialog from "./MessageDialog";
 interface PersonProps {
   updatePerson: (newPersonData: { [target: string]: unknown }) => void;
   deletePerson: () => void;
+  setAlert: (open: boolean, message?:string, severity?:string) => void;
   viewErrorTrigger: number;
   person: IFormPerson;
 }
@@ -38,6 +39,7 @@ const initState: { [data: string]: any } = {
 const InstitutionPerson: FC<PersonProps> = ({
   updatePerson,
   deletePerson,
+  setAlert,
   viewErrorTrigger,
   person,
 }) => {
@@ -210,9 +212,14 @@ const InstitutionPerson: FC<PersonProps> = ({
           setShowMessageDialog(true);
         }}
       >
+        { person.comment.length == 0 &&
         <Typography>
-        Legg til en kommentar for denne personen
+          Legg til en kommentar for denne personen
+        </Typography> ||
+        <Typography>
+          Se/endre kommentaren for denne personen
         </Typography>
+        }
       </Link>
       </Grid>
       <Grid>
@@ -220,6 +227,8 @@ const InstitutionPerson: FC<PersonProps> = ({
         open={state.dialogOpen}
         onClose={() => setShowMessageDialog(false)}
         setMessage={setValidMessage}
+        message={person.comment}
+        setAlert={() => setAlert(true)}
       />
       </Grid>
     </Grid>

--- a/ClientApp/src/components/institution/FormPerson.tsx
+++ b/ClientApp/src/components/institution/FormPerson.tsx
@@ -19,10 +19,10 @@ import IFormPerson from "./IFormPerson";
 import MessageDialog from "./MessageDialog";
 
 
-interface PersonProps {
+interface IPersonProps {
   updatePerson: (newPersonData: { [target: string]: unknown }) => void;
   deletePerson: () => void;
-  setAlert: (open: boolean, message?:string, severity?:string) => void;
+  setAlert: (open?: boolean, message?:string, severity?:"error" | "info" | "success" | "warning") => void;
   viewErrorTrigger: number;
   person: IFormPerson;
 }
@@ -36,7 +36,7 @@ const initState: { [data: string]: any } = {
   comment: "",
 };
 
-const InstitutionPerson: FC<PersonProps> = ({
+const InstitutionPerson: FC<IPersonProps> = ({
   updatePerson,
   deletePerson,
   setAlert,
@@ -228,7 +228,7 @@ const InstitutionPerson: FC<PersonProps> = ({
         onClose={() => setShowMessageDialog(false)}
         setMessage={setValidMessage}
         message={person.comment}
-        setAlert={() => setAlert(true)}
+        setAlert={setAlert}
       />
       </Grid>
     </Grid>

--- a/ClientApp/src/components/institution/IFormPerson.tsx
+++ b/ClientApp/src/components/institution/IFormPerson.tsx
@@ -6,7 +6,7 @@ interface IFormPerson {
   age: string;
   months: string;
   gender: Gender;
-  comment: String;
+  comment: string;
   wish?: string; // Age-adjusted gift if undefined
   isValidAge: boolean;
   isValidGender: boolean;

--- a/ClientApp/src/components/institution/InstitutionForm.tsx
+++ b/ClientApp/src/components/institution/InstitutionForm.tsx
@@ -416,7 +416,7 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
       <Snackbar
         anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         open={state.alert.open}
-        autoHideDuration={60000}
+        autoHideDuration={6000}
         onClose={handleAlertClose}
       >
         <Alert severity={state.alert.severity} onClose={handleAlertClose}>
@@ -444,6 +444,7 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
                 {formDataState.persons.map((person, i) => {
                   return (
                     <FormPerson
+                      setAlert={() => setAlert(true)}
                       key={person.uuid}
                       person={person}
                       viewErrorTrigger={state.viewErrorTrigger}

--- a/ClientApp/src/components/institution/InstitutionForm.tsx
+++ b/ClientApp/src/components/institution/InstitutionForm.tsx
@@ -257,7 +257,7 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
 
   const setAlert = (
     open?: boolean,
-    message?: React.ReactNode,
+    message?: React.ReactNode | string,
     severity?: "error" | "info" | "success" | "warning"
   ) => {
     setState((prev) => ({
@@ -444,7 +444,7 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
                 {formDataState.persons.map((person, i) => {
                   return (
                     <FormPerson
-                      setAlert={() => setAlert(true)}
+                      setAlert={setAlert}
                       key={person.uuid}
                       person={person}
                       viewErrorTrigger={state.viewErrorTrigger}

--- a/ClientApp/src/components/institution/MessageDialog.tsx
+++ b/ClientApp/src/components/institution/MessageDialog.tsx
@@ -10,7 +10,6 @@ import {
   } from "@material-ui/core";
   import CloseIcon from "@material-ui/icons/Close";
   import { FC, useState } from "react";
-  import useStyles from "./Styles";
   
   const style = {
     dialogWidth: {
@@ -20,6 +19,8 @@ import {
 
   interface IMessageDialog {
     setMessage: (message: string) => void;
+    setAlert: (open: boolean, message?:string, severity?:string) => void;
+    message: string;
     onClose: () => void;
     open: boolean;
   }
@@ -27,25 +28,29 @@ import {
   const MessageDialog
   : FC<IMessageDialog> = ({
     setMessage,
+    setAlert,
+    message,
     onClose,
     open,
   }) => {
-    const classes = useStyles();
-  
     const [value, setValue] = useState("");
 
     const onCommentChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setValue(e.target.value);
-        setMessage(e.target.value);
+        setValue(() => e.target.value);
       };
 
     const handleSubmit = () => {
     setMessage(value);
+    setAlert(true, "Kommentar oppdatert!", "success");
     onClose();
     };
-  
+
+    const onCommentOpen = () => {
+      setValue(message)
+    }
+    
     return (
-      <Dialog onClose={onClose} aria-labelledby="dialog-title" open={open}>
+      <Dialog onClose={() => {onClose(); onCommentOpen()}} aria-labelledby="dialog-title" open={open}>
         <DialogTitle id="dialog-title" disableTypography>
           <Typography
           style={style.dialogWidth}
@@ -56,7 +61,7 @@ import {
           {onClose ? (
             <IconButton
               aria-label="close"
-              onClick={onClose}
+              onClick={() => {onClose(); onCommentOpen()}}
             >
               <CloseIcon />
             </IconButton>
@@ -76,7 +81,14 @@ import {
         </DialogContent>
             <DialogActions>
                 <Button onClick={handleSubmit} color="primary">
+                  {message.length == 0 &&
+                  <Typography>
                     Legg til kommentar
+                  </Typography> ||
+                  <Typography>
+                    Endre kommentar
+                  </Typography>
+                  }
                 </Button>
             </DialogActions>
       </Dialog>

--- a/ClientApp/src/components/institution/MessageDialog.tsx
+++ b/ClientApp/src/components/institution/MessageDialog.tsx
@@ -19,7 +19,7 @@ import {
 
   interface IMessageDialog {
     setMessage: (message: string) => void;
-    setAlert: (open: boolean, message?:string, severity?:string) => void;
+    setAlert: (open?: boolean, message?:string, severity?:"error" | "info" | "success" | "warning") => void;
     message: string;
     onClose: () => void;
     open: boolean;


### PR DESCRIPTION
Its now more clear what is going on when adding a comment to a person in a family.
The clickable link will now change its text from "Legg til" to "Se/Endre" to visually identify that a comment is added.
![Kommentar](https://user-images.githubusercontent.com/69798990/137080284-be1a959d-6f14-427a-b7b0-b022a560a426.PNG)
Adding or updating a comment will send an alert to notify that the comment is added.
![Alert](https://user-images.githubusercontent.com/69798990/137080436-3bb04cad-cdab-4b4d-8227-d4d981731d38.PNG)
Closing the comment tab rather than saving will undo unsaved changes.