### PR TITLE
Automatic location on institution page

### DIFF
--- a/ClientApp/src/components/institution/InstitutionForm.tsx
+++ b/ClientApp/src/components/institution/InstitutionForm.tsx
@@ -424,13 +424,13 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
           {state.alert.msg}
         </Alert>
       </Snackbar>
-
+      
       <form className="thisclass" onSubmit={onSubmitForm}>
         <Grid container spacing={4} direction="column">
           <Grid item>
             <Grid container spacing={1} direction="column">
               <Grid item>
-                <Typography variant="h5">Familie</Typography>
+                <Typography variant="h5">Du registrerer nå familie i {location}</Typography>
               </Grid>
               <Grid item>
                 {formDataState.persons.map((person, i) => {

--- a/ClientApp/src/hooks/useUser.tsx
+++ b/ClientApp/src/hooks/useUser.tsx
@@ -39,9 +39,9 @@ const reducer = (state: IState, action: IReducerAction) => {
     case ReducerActionType.setLocation:
       return { ...state, location: action.data ?? null };
     case ReducerActionType.setRole:
-      return { ...state, role: action.data ?? "Unspecified" };
+      return { ...state, role: action.data ?? null };
     case ReducerActionType.setInstitution:
-      return { ...state, institution: action.data ?? "Unspecified" };
+      return { ...state, institution: action.data ?? null };
     default:
       throw new Error(`Invalid action type: ${action.type}`);
   }


### PR DESCRIPTION
Location on institution page is now removed and rather uses the location registered on the user to automatically select a location.
This is also the case for the Institution where eg. NAV or Barneværnet is read from its user rather than being statically added.

#414 