### PR TITLE
379/endpoint removing connections

### DIFF
--- a/GiEnJul/Auth/Authconfig.cs
+++ b/GiEnJul/Auth/Authconfig.cs
@@ -19,6 +19,7 @@ namespace GiEnJul.Auth
             opt.AddPolicy("AddConnection", policy => policy.RequireClaim("permissions", "add:connection"));
             opt.AddPolicy("GetUnsuggestedGivers", policy => policy.RequireClaim("permissions", "get:unsuggestedgivers"));
             opt.AddPolicy("GetUnsuggestedRecipients", policy => policy.RequireClaim("permissions", "get:unsuggestedrecipients"));
+            opt.AddPolicy("DeleteConnection", policy => policy.RequireClaim("permissions", "delete:connection"));
         }
     }
 }

--- a/GiEnJul/Controllers/AdminController.cs
+++ b/GiEnJul/Controllers/AdminController.cs
@@ -165,11 +165,8 @@ namespace GiEnJul.Controllers
             {
                 await _giverRepository.InsertOrReplaceAsync(giver);
                 await _recipientRepository.InsertOrReplaceAsync(recipient);
-
-                if (await _connectionRepository.ConnectionExists(giver, recipient))
-                {
-                    await _connectionRepository.DeleteConnectionAsync(location, recipient.RowKey + "_" + giver.RowKey);
-                }
+                
+                await _connectionRepository.DeleteConnectionAsync(location, recipient.RowKey + "_" + giver.RowKey);
             }
             catch (Exception e)
             {

--- a/GiEnJul/Controllers/AdminController.cs
+++ b/GiEnJul/Controllers/AdminController.cs
@@ -133,7 +133,7 @@ namespace GiEnJul.Controllers
         }
 
         [HttpDelete("Connection")]
-        // [Authorize(Policy = "DeleteConnection")]
+        [Authorize(Policy = "DeleteConnection")]
         public async Task<ActionResult> DeleteConnectionAsync(string location, string rowKey)
         {
             var giver = await _giverRepository.GetGiverAsync(location, rowKey);

--- a/GiEnJul/Models/Giver.cs
+++ b/GiEnJul/Models/Giver.cs
@@ -20,5 +20,10 @@ namespace GiEnJul.Models
         //Match with family, default is false
         public bool IsSuggestedMatch { get; set; } = false;
         public bool HasConfirmedMatch { get; set; } = false;
+
+        public Giver ShallowCopy() 
+        {
+            return (Giver) this.MemberwiseClone();
+        }
     }
 }

--- a/GiEnJul/Models/Recipient.cs
+++ b/GiEnJul/Models/Recipient.cs
@@ -31,5 +31,10 @@ namespace GiEnJul.Models
 
         public List<Person> FamilyMembers { get; set; } = new List<Person>();
         public int PersonCount { get; set; }
+
+        public Recipient ShallowCopy()
+        {
+            return (Recipient) this.MemberwiseClone();
+        }
     }
 }


### PR DESCRIPTION
Open for suggestions/improvements

The new endpoint `admin/connection?location=...&rowKey=...` takes location and rowkey of a giver as input, and deletes the corresponding connection. This includes both completed connections and connections waiting to be confirmed.