### PR TITLE
Fix454/institution overview families

### DIFF
--- a/ClientApp/src/components/admin/overview/Recipient.tsx
+++ b/ClientApp/src/components/admin/overview/Recipient.tsx
@@ -25,9 +25,11 @@ const Recipient: React.FC<Props> = ({
         input.contactFullName?.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
         input.contactPhoneNumber?.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
         input.institution?.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
-        input.referenceId?.toLowerCase().indexOf(query.toLowerCase()) > -1
+        input.referenceId?.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
+        input.familyId.toString()?.toLocaleLowerCase().indexOf(query.toLowerCase()) > -1
     );
   };
+
   const classes= useStyles();
 
   return (

--- a/ClientApp/src/components/admin/overview/Recipient.tsx
+++ b/ClientApp/src/components/admin/overview/Recipient.tsx
@@ -26,7 +26,7 @@ const Recipient: React.FC<Props> = ({
         input.contactPhoneNumber?.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
         input.institution?.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
         input.referenceId?.toLowerCase().indexOf(query.toLowerCase()) > -1 ||
-        input.familyId.toString()?.toLocaleLowerCase().indexOf(query.toLowerCase()) > -1
+        input.familyId.toString()?.toLowerCase().indexOf(query.toLowerCase()) > -1
     );
   };
 

--- a/ClientApp/src/components/institution/ConfirmationDialog.tsx
+++ b/ClientApp/src/components/institution/ConfirmationDialog.tsx
@@ -21,7 +21,7 @@ interface IConfirmationDialog {
     referenceId,
     handleClose,
   }) => {
-
+    console.log("confirmation dialog")
 return (
     <div>
       <Dialog

--- a/ClientApp/src/components/institution/ConfirmationDialog.tsx
+++ b/ClientApp/src/components/institution/ConfirmationDialog.tsx
@@ -21,8 +21,8 @@ interface IConfirmationDialog {
     referenceId,
     handleClose,
   }) => {
-    console.log("confirmation dialog")
-return (
+
+    return (
     <div>
       <Dialog
         open={open}

--- a/ClientApp/src/components/institution/FamilyDialog.tsx
+++ b/ClientApp/src/components/institution/FamilyDialog.tsx
@@ -4,32 +4,29 @@
      DialogActions, 
      DialogContent, 
      DialogContentText, 
-     DialogTitle
+     DialogTitle, 
  } from "@material-ui/core";
  import {GiverType, RecipientType, SelectedConnectionType} from "../admin/overview/Types";
  import Recipient from "../admin/overview/Recipient";
  import ApiService from "../../common/functions/apiServiceClass";
  import { useEffect, useState, useCallback} from "react";
- import useUser from '../../hooks/useUser';
 
  const initState: SelectedConnectionType= {
     recipient: undefined,
   };
 
- interface IFamilyDialog{
+interface IFamilyDialog{
      open: boolean;
      accessToken: string; 
+     institution?: string;
      handleClose : () => void;
  }
  
-const FamilyDialog: React.FC<IFamilyDialog> = ({accessToken, open, handleClose}) => {
+const FamilyDialog: React.FC<IFamilyDialog> = ({ open, accessToken,institution, handleClose}) => {
     const [recipientData, setRecipientData] = useState<RecipientType[] | []>([]);
     const [selectedConnection, setSelectedConnection] = useState<SelectedConnectionType>(initState);
     const apiservice = new ApiService(accessToken);
-
-    const { institution } = useUser();
-    console.log("new", institution)
-
+ 
     const fetchRecipients = () =>{
         apiservice
         .get("Recipient", { params: { Institution: institution } })
@@ -38,10 +35,10 @@ const FamilyDialog: React.FC<IFamilyDialog> = ({accessToken, open, handleClose})
         .catch((errorStack) => {
           console.error(errorStack)
         });
-      }
+    }
     
       useEffect(() => {
-        fetchRecipients();
+          fetchRecipients();
       }, []);
     
     const handleRecipientChange = useCallback((newRecipient: RecipientType) => {
@@ -65,7 +62,7 @@ const FamilyDialog: React.FC<IFamilyDialog> = ({accessToken, open, handleClose})
       }, []);
     return (
          <div>
-             <Dialog open={open} aria-labelledby="alert-dialog-title" aria-describedby="alert-dialog-description">
+             <Dialog fullWidth={true} open={open} aria-labelledby="alert-dialog-title" aria-describedby="alert-dialog-description">
                  <DialogTitle id="alert-dialog-title">
                      {"Tidligere registrerte familier"}
                  </DialogTitle>

--- a/ClientApp/src/components/institution/FamilyDialog.tsx
+++ b/ClientApp/src/components/institution/FamilyDialog.tsx
@@ -1,0 +1,88 @@
+ import {
+     Button, 
+     Dialog, 
+     DialogActions, 
+     DialogContent, 
+     DialogContentText, 
+     DialogTitle
+ } from "@material-ui/core";
+ import {GiverType, RecipientType, SelectedConnectionType} from "../admin/overview/Types";
+ import Recipient from "../admin/overview/Recipient";
+ import ApiService from "../../common/functions/apiServiceClass";
+ import { useEffect, useState, useCallback} from "react";
+ import useUser from '../../hooks/useUser';
+
+ const initState: SelectedConnectionType= {
+    recipient: undefined,
+  };
+
+ interface IFamilyDialog{
+     open: boolean;
+     accessToken: string; 
+     handleClose : () => void;
+ }
+ 
+const FamilyDialog: React.FC<IFamilyDialog> = ({accessToken, open, handleClose}) => {
+    const [recipientData, setRecipientData] = useState<RecipientType[] | []>([]);
+    const [selectedConnection, setSelectedConnection] = useState<SelectedConnectionType>(initState);
+    const apiservice = new ApiService(accessToken);
+
+    const { institution } = useUser();
+    console.log("new", institution)
+
+    const fetchRecipients = () =>{
+        apiservice
+        .get("Recipient", { params: { Institution: institution } })
+        .then((resp) => {
+          setRecipientData(resp.data)})
+        .catch((errorStack) => {
+          console.error(errorStack)
+        });
+      }
+    
+      useEffect(() => {
+        fetchRecipients();
+      }, []);
+    
+    const handleRecipientChange = useCallback((newRecipient: RecipientType) => {
+        if (!newRecipient.isSuggestedMatch && !newRecipient.hasConfirmedMatch) {
+          if (selectedConnection.recipient?.rowKey === newRecipient.rowKey) {
+            setSelectedConnection((prevState) => {
+              return {
+                ...prevState,
+                recipient: undefined,
+              };
+            });
+          } else {
+            setSelectedConnection((prevState) => {
+              return {
+                ...prevState,
+                recipient: newRecipient,
+              };
+            });
+          }
+        }
+      }, []);
+    return (
+         <div>
+             <Dialog open={open} aria-labelledby="alert-dialog-title" aria-describedby="alert-dialog-description">
+                 <DialogTitle id="alert-dialog-title">
+                     {"Tidligere registrerte familier"}
+                 </DialogTitle>
+                 <DialogContent>
+                     <DialogContentText id="alert-dialog-description">
+                         <p>Liste over familier</p>
+                     </DialogContentText>
+                     <Recipient data={recipientData} handleRecipientChange={handleRecipientChange}/>
+                 </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose}>
+                        Lukk vindu
+                    </Button>
+                </DialogActions>
+             </Dialog>
+         </div>
+     );
+ };
+
+ export default FamilyDialog;

--- a/ClientApp/src/components/institution/FamilyDialog.tsx
+++ b/ClientApp/src/components/institution/FamilyDialog.tsx
@@ -6,7 +6,7 @@
      DialogContentText, 
      DialogTitle, 
  } from "@material-ui/core";
- import {GiverType, RecipientType, SelectedConnectionType} from "../admin/overview/Types";
+ import {RecipientType, SelectedConnectionType} from "../admin/overview/Types";
  import Recipient from "../admin/overview/Recipient";
  import ApiService from "../../common/functions/apiServiceClass";
  import { useEffect, useState, useCallback} from "react";

--- a/ClientApp/src/components/institution/InstitutionForm.tsx
+++ b/ClientApp/src/components/institution/InstitutionForm.tsx
@@ -414,6 +414,7 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
   };
 
 
+
   const closeFamilyDialog = () => {
     setShowFamilyDialog(false);
   }
@@ -440,7 +441,9 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
           <Grid item>
             <Typography variant="h5">Tidligere registrerte familier </Typography>
             <Button onClick={openFamilyDialog} variant="contained" color="primary"> Klikk her for å se familieoversikt </Button>
-            <FamilyDialog open={showFamilyDialog} accessToken={accessToken}  handleClose={closeFamilyDialog}/>
+            <Grid item >
+              {showFamilyDialog == true ? <FamilyDialog open={true} accessToken={accessToken} institution={institution} handleClose={closeFamilyDialog}/> : <Typography> <br></br></Typography> }
+            </Grid>
             <Grid container spacing={1} direction="column">
               <Grid item>
                 <Typography variant="h5">Du registrerer nå familie i {location}</Typography>

--- a/ClientApp/src/components/institution/InstitutionForm.tsx
+++ b/ClientApp/src/components/institution/InstitutionForm.tsx
@@ -9,7 +9,7 @@ import { Alert } from "@material-ui/lab";
 import HelpOutlineIcon from '@material-ui/icons/HelpOutline';
 import CheckCircleIcon from '@material-ui/icons/CheckCircle';
 import * as React from "react";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback} from "react";
 import { DESSERTS } from "../../common/constants/Desserts";
 import { DINNERS } from "../../common/constants/Dinners";
 import Gender from "../../common/enums/Gender";
@@ -17,6 +17,7 @@ import ApiService from "../../common/functions/apiServiceClass";
 import InputValidator from "../InputFields/Validators/InputValidator";
 import Tooltip from '@material-ui/core/Tooltip';
 import ConfirmationDialog from './ConfirmationDialog';
+import FamilyDialog from './FamilyDialog';
 
 import {
   isEmail,
@@ -80,7 +81,8 @@ const initState: {
     referenceId:string;
     familyId:string;
     open: boolean;
-  }
+  }; 
+
 } = {
   viewErrorTrigger: 0,
   displayText: false, 
@@ -136,21 +138,20 @@ interface props {
 
 const RegistrationForm: React.FC<props> = ({ accessToken }) => {
   const [state, setState] = useState(initState);
-
+  const [showFamilyDialog, setShowFamilyDialog] = useState(false);
   const [formDataState, setFormDataState] = useState(initFormDataState());
   const [validFormState, setValidFormState] = useState({
     ...initValidFormState,
   });
   const apiservice = new ApiService(accessToken);
-
   const addPerson = () => {
     setFormDataState((prev) => ({
       ...prev,
       persons: [...prev.persons, getFormPerson()],
     }));
   };
-  
-  
+
+
   const { location, role, institution } = useUser();
 
   const closeDialog = () => {
@@ -412,6 +413,15 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
     setAlert(false);
   };
 
+
+  const closeFamilyDialog = () => {
+    setShowFamilyDialog(false);
+  }
+
+  const openFamilyDialog = () => {
+    setShowFamilyDialog(true);
+  }
+
   return (
     <>
       <Snackbar
@@ -428,6 +438,9 @@ const RegistrationForm: React.FC<props> = ({ accessToken }) => {
       <form className="thisclass" onSubmit={onSubmitForm}>
         <Grid container spacing={4} direction="column">
           <Grid item>
+            <Typography variant="h5">Tidligere registrerte familier </Typography>
+            <Button onClick={openFamilyDialog} variant="contained" color="primary"> Klikk her for å se familieoversikt </Button>
+            <FamilyDialog open={showFamilyDialog} accessToken={accessToken}  handleClose={closeFamilyDialog}/>
             <Grid container spacing={1} direction="column">
               <Grid item>
                 <Typography variant="h5">Du registrerer nå familie i {location}</Typography>

--- a/GiEnJul/Controllers/RecipientController.cs
+++ b/GiEnJul/Controllers/RecipientController.cs
@@ -65,5 +65,18 @@ namespace GiEnJul.Controllers
                 throw ex;
             }
         }
+
+        [HttpGet]
+        [Authorize(Policy = "ReadRecipient")]
+        public async Task<List<Recipient>> GetRecipientsByInstitutionAsync([FromQuery] string institution)
+        {
+            
+            var recipients = await _recipientRepository.GetRecipientsByInstitutionAsync(institution);
+            foreach (var recipient in recipients)
+            {
+                recipient.FamilyMembers = await _personRepository.GetAllByRecipientId(recipient.RowKey);
+            }
+            return recipients;
+        }
     }
 }

--- a/GiEnJul/Repositories/RecipientRepository.cs
+++ b/GiEnJul/Repositories/RecipientRepository.cs
@@ -18,6 +18,7 @@ namespace GiEnJul.Repositories
         Task<IList<Models.Recipient>> GetUnsuggestedAsync(string eventName, string location, int quantity);
         Task<List<Models.Recipient>> GetSuggestedAsync(string eventName, string location);
         Task<List<Models.Recipient>> GetRecipientsByLocationAsync(string eventName, string location);
+        Task<List<Models.Recipient>> GetRecipientsByInstitutionAsync(string institution);
     }
     public class RecipientRepository : GenericRepository<Entities.Recipient>, IRecipientRepository
     {
@@ -86,6 +87,15 @@ namespace GiEnJul.Repositories
             var filter = TableQueryFilterHelper.GetAllByActiveEventsFilter(eventName, location);
             var query = new TableQuery<Entities.Recipient>().Where(filter);
             var recipients = await GetAllByQueryAsync(query);
+            return _mapper.Map<List<Models.Recipient>>(recipients);
+        }
+
+        public async Task<List<Models.Recipient>> GetRecipientsByInstitutionAsync(string institution)
+        {
+            var filter = TableQuery.GenerateFilterCondition("Institution", QueryComparisons.Equal, institution);
+            var query = new TableQuery<Entities.Recipient>().Where(filter);
+            var recipients = await GetAllByQueryAsync(query);
+
             return _mapper.Map<List<Models.Recipient>>(recipients);
         }
     }


### PR DESCRIPTION
Fixes #454 

- Makes it possible for institution to view previously added families. 
- Currently all employees are registered under "NAV", will make it personal for each workplace (NAV hs, barnevernet etc..)