### PR TITLE
Fix edit family dialog

### DIFF
--- a/ClientApp/src/components/admin/Styles.tsx
+++ b/ClientApp/src/components/admin/Styles.tsx
@@ -58,6 +58,9 @@ const useStyles = makeStyles((theme: Theme) =>
     headerSpacing: {
       marginTop: "1em",
     },
+    wishSpacing: {
+      marginTop: "1.2em",
+    },
   })
 );
 

--- a/ClientApp/src/components/admin/dashboard-all/GiverDataCard.tsx
+++ b/ClientApp/src/components/admin/dashboard-all/GiverDataCard.tsx
@@ -146,26 +146,20 @@ const GiverDataCard: React.FC<Props> = ({
 
   const saveComment = (response: boolean) => {
     if (response) {
-      if (requestState != RequestState.Waiting) {
-        setRequestState(RequestState.Waiting);
-        apiservice
-          .post("admin/giver/addcomment", {
-            event: giverData.event,
-            giverId: giverData.giverId,
-            comment: comment,
-          })
-          .then((resp) => {
-            if (resp.status === 200) {
-              setRequestState(RequestState.Ok);
-              refreshData();
-              resetSelections();
-            }
-          })
-          .catch((err) => {
-            setRequestState(RequestState.Error);
-            console.error(err);
-          });
-      }
+      apiservice
+        .post("admin/giver/addcomment", {
+          event: giverData.event,
+          giverId: giverData.giverId,
+          comment: comment,
+        })
+        .then((resp) => {
+          if (resp.status === 200) {
+            refreshData();
+          }
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     }
   };
 

--- a/ClientApp/src/components/admin/dashboard-all/RecipientDataCard.tsx
+++ b/ClientApp/src/components/admin/dashboard-all/RecipientDataCard.tsx
@@ -120,26 +120,20 @@ const RecipientDataCard: React.FC<Props> = ({
 
   const saveComment = (response: boolean) => {
     if (response) {
-      if (requestState != RequestState.Waiting) {
-        setRequestState(RequestState.Waiting);
-        apiservice
-          .post("admin/recipient/addcomment", {
-            event: recipientData.event,
-            recipientId: recipientData.recipientId,
-            comment: comment,
-          })
-          .then((resp) => {
-            if (resp.status === 200) {
-              setRequestState(RequestState.Ok);
-              refreshData();
-              resetSelections();
-            }
-          })
-          .catch((err) => {
-            setRequestState(RequestState.Error);
-            console.error(err);
-          });
-      }
+      apiservice
+        .post("admin/recipient/addcomment", {
+          event: recipientData.event,
+          recipientId: recipientData.recipientId,
+          comment: comment,
+        })
+        .then((resp) => {
+          if (resp.status === 200) {
+            refreshData();
+          }
+        })
+        .catch((err) => {
+          console.error(err);
+        });
     }
   };
 
@@ -315,13 +309,16 @@ const RecipientDataCard: React.FC<Props> = ({
                     <Grid container direction="column">
                       {!recipientData.isSuggestedMatch && (
                         <Grid item>
-                          <Typography
-                            onClick={() => {
-                              setOpenEditFamilyDialog(true);
-                            }}
-                          >
+                          <Typography>
                             <Edit />
-                            <Button>Rediger familie</Button>
+                            <Button
+                              className={classes.underlineText}
+                              onClick={() => {
+                                setOpenEditFamilyDialog(true);
+                              }}
+                            >
+                              Rediger familie
+                            </Button>
                           </Typography>
                           <EditFamilyDialog
                             open={openEditFamilyDialog}
@@ -337,9 +334,12 @@ const RecipientDataCard: React.FC<Props> = ({
                       )}
                       {recipientData.isSuggestedMatch && (
                         <Grid item>
-                          <Typography onClick={() => setOpenDelConnectionDialog(true)}>
+                          <Typography>
                             <LinkOutlined />
-                            <Button className={classes.underlineText}>
+                            <Button
+                              className={classes.underlineText}
+                              onClick={() => setOpenDelConnectionDialog(true)}
+                            >
                               Koble fra giver og familie
                             </Button>
                           </Typography>
@@ -354,9 +354,14 @@ const RecipientDataCard: React.FC<Props> = ({
                         </Grid>
                       )}
                       <Grid item>
-                        <Typography onClick={() => setOpenDelFamilyDialog(true)}>
+                        <Typography>
                           <LinkOutlined />
-                          <Button className={classes.underlineText}>Slett familie</Button>
+                          <Button
+                            className={classes.underlineText}
+                            onClick={() => setOpenDelFamilyDialog(true)}
+                          >
+                            Slett familie
+                          </Button>
                         </Typography>
                         <ConfirmationBox
                           open={openDelFamilyDialog}

--- a/ClientApp/src/components/shared/EditFamilyDialog.tsx
+++ b/ClientApp/src/components/shared/EditFamilyDialog.tsx
@@ -55,6 +55,7 @@ const EditFamilyDialog: FC<IEditFamilyDialog> = ({
   useEffect(() => {
     if (open) {
       setRecipientData(recipient);
+      fetchMuncipalityEmail();
     }
   }, [open]);
 
@@ -279,9 +280,15 @@ const EditFamilyDialog: FC<IEditFamilyDialog> = ({
   };
 
   const updateRecipient = async () => {
-    fetchMuncipalityEmail();
+    const submitData = { ...recipientData };
+    submitData.familyMembers.forEach((person) => {
+      if (person.noWish) {
+        person.wishes = ["Alderstilpasset gaveønske"];
+      }
+    });
+
     await apiservice
-      .put("admin/recipient", JSON.stringify(recipientData))
+      .put("admin/recipient", JSON.stringify(submitData))
       .then((response) => {
         if (response.status === 200) {
           refreshRecipients();
@@ -455,12 +462,14 @@ const EditFamilyDialog: FC<IEditFamilyDialog> = ({
                                     value={wish ? wish : ""}
                                     onChange={onWishChange(fIndex, wIndex)}
                                   />
-                                  <IconButton
-                                    aria-label="close"
-                                    onClick={() => removeWish(fIndex, wIndex)}
-                                  >
-                                    <CloseIcon />
-                                  </IconButton>
+                                  {recipientData.familyMembers[fIndex].wishes.length > 1 && (
+                                    <IconButton
+                                      aria-label="close"
+                                      onClick={() => removeWish(fIndex, wIndex)}
+                                    >
+                                      <CloseIcon />
+                                    </IconButton>
+                                  )}
                                 </Box>
                               );
                             })}
@@ -504,6 +513,9 @@ const EditFamilyDialog: FC<IEditFamilyDialog> = ({
                             variant="contained"
                             color="primary"
                             onClick={() => addWish(fIndex)}
+                            disabled={
+                              recipientData.familyMembers[fIndex].wishes.length < 5 ? false : true
+                            }
                           >
                             Nytt Ønske
                           </Button>


### PR DESCRIPTION
When editing family, you can now;
- Add wishes
- Remove wishes
- Toggle Age Appropriate

Also, on both cards;
- Comments does not reset selections
- Comments does not rely on request state

Lastly;
- onClick moved to button from typography, as you could click it outside button range
- Removed attempted memory leak fix, as it did not work after all