### PR TITLE
fix footer, municipality tabs, only fetch users for the applicable roles

### DIFF
--- a/ClientApp/src/components/landing-page/Municipalities/Municipalities.tsx
+++ b/ClientApp/src/components/landing-page/Municipalities/Municipalities.tsx
@@ -3,8 +3,9 @@ import useStyles from "./Styles";
 import { TabContext, TabList, TabPanel } from "@material-ui/lab";
 import { useEffect, useState } from "react";
 import MunicipalityInformation from "./MunicipalityInformation";
-import { useLocation } from "react-router-dom";
 import React from "react";
+import useIsMobile from "hooks/useIsMobile";
+import useGetSearchParams from "hooks/useGetSearchParam";
 
 export interface LocationData {
   location: string;
@@ -21,16 +22,18 @@ const Municipalities: React.FC<Props> = ({ locations }) => {
     setTab(newValue);
   };
   const classes = useStyles();
+  const isMobile = useIsMobile();
+  const getSearchParam = useGetSearchParams();
 
-  function useQuery() {
-    const { search } = useLocation();
+  const [tab, setTab] = useState<string>(getSearchParam("location") ?? "");
 
-    return React.useMemo(() => new URLSearchParams(search), [search]);
-  }
-
-  const query = useQuery();
-
-  const [tab, setTab] = useState<string>("");
+  useEffect(() => {
+    const loc = getSearchParam("location");
+    if (loc && locations.map((l) => l.location.toLowerCase()).includes(loc)) {
+      setTab(loc);
+      return;
+    }
+  }, [getSearchParam]);
 
   const kommuneTabs = locations.map((val) => (
     <Tab
@@ -39,15 +42,6 @@ const Municipalities: React.FC<Props> = ({ locations }) => {
       label={val.location}
     />
   ));
-
-  useEffect(() => {
-    const location = query.get("location");
-    if (!location && locations.length) {
-      setTab(locations[0].location.toLowerCase());
-      return;
-    }
-    if (location) setTab(location);
-  }, [location, locations]);
 
   const kommuneTabPanels = locations.map((val) => (
     <TabPanel
@@ -65,7 +59,14 @@ const Municipalities: React.FC<Props> = ({ locations }) => {
   return (
     <Container className={classes.sectionContainer}>
       <TabContext value={tab}>
-        <TabList onChange={handleChange} centered>
+        <TabList
+          onChange={handleChange}
+          variant={
+            (isMobile && locations.length > 4) || locations.length > 7 ? "scrollable" : "standard"
+          }
+          centered={(isMobile && locations.length > 4) || locations.length > 7 ? false : true}
+          scrollButtons="auto"
+        >
           {kommuneTabs}
         </TabList>
         {kommuneTabPanels}

--- a/ClientApp/src/components/shared/Footer.tsx
+++ b/ClientApp/src/components/shared/Footer.tsx
@@ -4,7 +4,6 @@ import * as React from "react";
 import { useEffect, useState } from "react";
 import useStyles from "./Styles";
 import { Link } from "react-router-dom";
-import { Link as Scroll } from "react-scroll";
 
 const Footer: React.FC = () => {
   const classes = useStyles();
@@ -19,66 +18,71 @@ const Footer: React.FC = () => {
   useEffect(() => fetchActive(), []);
 
   return (
-    <>
-      <Grid className={classes.footer}>
+    <Grid container direction="column" className={classes.footer}>
+      <Grid item>
         <Grid container direction="row" justifyContent="space-evenly">
-          <Grid item>
-            <Typography variant="h6" className={classes.footerHeadline}>
-              <b>Sider</b>
-            </Typography>
-
-            <Grid item direction="column">
-              <Link className={classes.footerHeadline} to="/kommune">
-                <b>Kommuneinformasjon</b>
-              </Link>
-              {municipalities.map((municipality, index) => {
-                return (
-                  <Grid item key={index}>
-                    <Link
-                      className={classes.footerHeadline}
-                      to={`kommune?location=${municipality.toLowerCase()}`}
-                    >
-                      {municipality}
+          <Grid item xs={4}>
+            <Grid container direction="column">
+              <Grid item>
+                <Typography variant="h6" className={classes.footerHeadline}>
+                  <b>Sider</b>
+                </Typography>
+              </Grid>
+              <Grid item>
+                <Grid container direction="column">
+                  <Grid item>
+                    <Link className={classes.footerHeadline} to="/kommune">
+                      <b>Kommuneinformasjon</b>
                     </Link>
                   </Grid>
-                );
-              })}
+                  {municipalities.map((municipality, index) => {
+                    return (
+                      <Grid item key={index}>
+                        <Link
+                          className={classes.footerHeadline}
+                          to={`kommune?location=${municipality.toLowerCase()}`}
+                        >
+                          {municipality}
+                        </Link>
+                      </Grid>
+                    );
+                  })}
+                </Grid>
+              </Grid>
+            </Grid>
+          </Grid>
+          <Grid item xs={4}>
+            <Grid container direction="column">
+              <Grid item>
+                <Typography variant="h6" className={classes.footerHeadline}>
+                  <b>Hjelp</b>
+                </Typography>
+              </Grid>
               <Grid item>
                 <Link className={classes.footerHeadline} to="startjul">
                   Hvordan starte Gi en jul i din kommune
                 </Link>
               </Grid>
               <Grid item>
-                <Link className={classes.footerHeadline} to="/bli-giver">
-                  Bli giver
-                </Link>
+                <a className={classes.footerHeadline} href="/#questions">
+                  FAQs
+                </a>
+              </Grid>
+              <Grid item>
+                <a className={classes.footerHeadline} href="/#contacts">
+                  Kontakt
+                </a>
               </Grid>
             </Grid>
           </Grid>
-          <Grid item direction="column">
-            <Typography variant="h6" className={classes.footerHeadline}>
-              <b>Hjelp</b>
-            </Typography>
-
-            <Grid item>
-              <Scroll className={classes.footerHeadline} to="questions">
-                FAQs
-              </Scroll>
-            </Grid>
-            <Grid item>
-              <Scroll className={classes.footerHeadline} to="contacts">
-                Kontakt
-              </Scroll>
-            </Grid>
-          </Grid>
-        </Grid>
-        <Grid item>
-          <Typography className={classes.footerText}>
-            Gi en jul &copy; {new Date().getFullYear()}
-          </Typography>
         </Grid>
       </Grid>
-    </>
+      <Grid item>
+        <Typography className={classes.footerText}>
+          Gi en jul &copy; {new Date().getFullYear()}
+        </Typography>
+      </Grid>
+    </Grid>
   );
 };
 export default Footer;

--- a/ClientApp/src/hooks/useGetSearchParam.tsx
+++ b/ClientApp/src/hooks/useGetSearchParam.tsx
@@ -1,0 +1,23 @@
+import { useCallback } from "react";
+import { useLocation } from "react-router-dom";
+
+const useGetSearchParams = () => {
+  const location = useLocation();
+
+  const getSearchParam = useCallback(
+    (param: string) => {
+      const params = location.search.split("?").filter((s) => s.startsWith(param));
+      if (!params.length) return null;
+
+      const split = params[0].split("=");
+      if (split.length !== 2) return null;
+
+      return split[1];
+    },
+    [location]
+  );
+
+  return getSearchParam;
+};
+
+export default useGetSearchParams;

--- a/ClientApp/src/pages/municipality/index.tsx
+++ b/ClientApp/src/pages/municipality/index.tsx
@@ -23,6 +23,7 @@ const Municipality = () => {
   const [activeMunicipalities, setActiveMunicipalities] = useState<string[]>([]);
   const [municipalityMap, setMunicipalityMap] = useState(new Map<string, IKommuneInfoResponse>());
   const [municipalityData, setMunicipalityData] = useState<LocationData[]>([]);
+  const [fallbackText, setFallbackText] = useState("Henter informasjon...");
 
   const classes = useStyles();
   const apiservice = new ApiService();
@@ -50,6 +51,9 @@ const Municipality = () => {
       })
       .catch((errorStack) => {
         console.error(errorStack);
+      })
+      .finally(() => {
+        setFallbackText("Det er ikke lagt til noe informasjon om kommunene enda");
       });
   };
 
@@ -91,7 +95,7 @@ const Municipality = () => {
             {activeMunicipalities.length > 0 ? (
               <Municipalities locations={municipalityData} />
             ) : (
-              <Typography>Det er ikke lagt til noe informasjon om kommunene enda</Typography>
+              <Typography>{fallbackText}</Typography>
             )}
           </Grid>
         </Grid>

--- a/GiEnJul/Clients/Auth0ManagementClient.cs
+++ b/GiEnJul/Clients/Auth0ManagementClient.cs
@@ -104,7 +104,14 @@ namespace GiEnJul.Clients
             var request = new GetUsersRequest();
             var users = await _managementApiClient.Users.GetAllAsync(request);
 
-            return (List<User>)users;
+            var adminUsers = await _managementApiClient.Roles.GetUsersAsync(_settings.Auth0Settings.Admin);
+            var superAdminUsers = await _managementApiClient.Roles.GetUsersAsync(_settings.Auth0Settings.SuperAdmin);
+            var institutionUsers = await _managementApiClient.Roles.GetUsersAsync(_settings.Auth0Settings.Institution);
+
+            return users.Where(u => adminUsers.Any(a => a.UserId == u.UserId)
+                            || superAdminUsers.Any(a => a.UserId == u.UserId)
+                            || institutionUsers.Any(a => a.UserId == u.UserId))
+                .ToList();
         }
 
         public async Task<User> GetSingleUser(string email)


### PR DESCRIPTION
Links in the footer now work.
Municipality tabs introduce scroll on mobile and if there are many.
The user management page for Super Admins will only fetch users that are in the roles defined for the current environment, meaning test users will not appear in production :) 