### PR TITLE
fix: email note in main text

### DIFF
--- a/ClientApp/src/components/landing-page/What.tsx
+++ b/ClientApp/src/components/landing-page/What.tsx
@@ -34,6 +34,13 @@ const What = () => {
             >
               Bli giver
             </Button>
+            <Typography className={classes.paragraph}>
+              <br />
+              Vi opplever problemer med e-post adresser fra hotmail og live.
+              <br />
+              Benytt gjerne en annen e-post adresse ved registrering.
+              <br />
+            </Typography>
             <Typography className={classes.paragraph + " " + classes.partnerText}>
               Med hjertelig støtte fra{" "}
               <a href={"https://www.capgemini.com/no-no"}>


### PR DESCRIPTION
<img width="406" height="898" alt="image" src="https://github.com/user-attachments/assets/f601b3bc-a6f9-47b1-a094-a881389830b2" />

Legger til et lite notat om e-postadresser som av og til har problemer.